### PR TITLE
[release/1.x-alpha] Updated bumped version for tide_core.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "GPL-2.0+",
   "version": "0.0.1",
   "require": {
-    "dpc-sdp/tide_core": "^1.6.11",
+    "dpc-sdp/tide_core": "^2.0.0",
     "dpc-sdp/tide_api": "^1.5.1",
     "dpc-sdp/tide_search": "^1.1.8"
   },


### PR DESCRIPTION
This is the branch that is going to be used for solar.