### PR TITLE
Release 4.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
   "type": "drupal-module",
   "license": "GPL-2.0+",
   "require": {
-    "dpc-sdp/tide_core": "^3.0.0",
-    "dpc-sdp/tide_api": "^3.0.0",
-    "dpc-sdp/tide_search": "^3.0.0"
+    "dpc-sdp/tide_core": "^4.0.0",
+    "dpc-sdp/tide_api": "^4.0.0",
+    "dpc-sdp/tide_search": "^4.0.0"
   },
   "suggest": {
     "dpc-sdp/tide_site:@dev": "Tide Site"

--- a/tide_automated_listing.info.yml
+++ b/tide_automated_listing.info.yml
@@ -2,7 +2,7 @@ name: Tide Automated Listing
 type: module
 description: 'Provides automated listing component for Tide Drupal 8 distribution.'
 package: Tide
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - dpc-sdp:tide_core
   - dpc-sdp:tide_api


### PR DESCRIPTION
Bump up `tide_` packages version
```
-    "dpc-sdp/tide_core": "^3.0.0",
-    "dpc-sdp/tide_api": "^3.0.0",
-    "dpc-sdp/tide_search": "^3.0.0"
+    "dpc-sdp/tide_core": "^4.0.0",
+    "dpc-sdp/tide_api": "^4.0.0",
+    "dpc-sdp/tide_search": "^4.0.0"
```
Bump up version in .info
```
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: ^9 || ^10
```